### PR TITLE
Add placeholder content for project tiles without backgrounds

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@
 <template id="tile-tpl">
     <article class="tile" tabindex="0" role="listitem">
         <img class="bg" alt=""/>
+        <div class="bg-placeholder" aria-hidden="true" hidden></div>
         <div class="scrim-base" aria-hidden="true"></div>
 
         <div class="award-ribbon" aria-hidden="true" hidden></div>

--- a/docs/portfolio-data.json
+++ b/docs/portfolio-data.json
@@ -29,6 +29,7 @@
                 {
                     "title": "Submerged",
                     "bg": "",
+                    "bgText": "Submerged",
                     "summary": "Largest map mod for Among Us",
                     "details": "Submerged is a mod for Among Us which adds a new underwater map into the game, featuring new tasks, sabotages and mechanics.",
                     "client": {
@@ -232,6 +233,7 @@
                 {
                     "title": "Subnautica Modder of the Year",
                     "summary": "Community awards site for Subnautica modders",
+                    "bgIcon": "github",
                     "client": {
                         "name": "Solo Project"
                     },

--- a/docs/portfolio.css
+++ b/docs/portfolio.css
@@ -270,6 +270,31 @@ h2 {
     transition: filter .2s ease, transform .2s ease, opacity .2s ease;
 }
 
+.bg-placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+    font-size: clamp(28px, 8vw, 72px);
+    font-weight: 800;
+    text-align: center;
+    color: rgba(255, 255, 255, .25);
+    letter-spacing: .08em;
+    z-index: 0;
+    pointer-events: none;
+}
+
+.bg-placeholder .icon {
+    font-size: clamp(42px, 10vw, 96px);
+    opacity: .65;
+}
+
+.bg-placeholder[hidden] {
+    display: none;
+}
+
 .scrim-base {
     position: absolute;
     inset: 0;

--- a/docs/portfolio.js
+++ b/docs/portfolio.js
@@ -105,12 +105,40 @@ const renderProject = (project, template) => {
     const fragment = template.content.cloneNode(true);
     const tile = select('.tile', fragment);
     const background = select('.bg', fragment);
+    const placeholder = select('.bg-placeholder', fragment);
 
     if (project.bg) {
         background.src = project.bg;
         background.hidden = false;
+        placeholder.hidden = true;
+        placeholder.innerHTML = '';
     } else {
+        background.removeAttribute('src');
         background.hidden = true;
+
+        const placeholderContent = (() => {
+            if (project.bgIcon) {
+                const icon = createIcon(project.bgIcon);
+                return icon;
+            }
+
+            if (project.bgText) {
+                const text = document.createElement('span');
+                text.textContent = project.bgText;
+                return text;
+            }
+
+            return null;
+        })();
+
+        placeholder.innerHTML = '';
+
+        if (placeholderContent) {
+            placeholder.append(placeholderContent);
+            placeholder.hidden = false;
+        } else {
+            placeholder.hidden = true;
+        }
     }
 
     applyText(select('.tile-title', fragment), project.title);


### PR DESCRIPTION
## Summary
- add a placeholder element to project tiles so missing backgrounds can be replaced with custom text or icons
- style and render placeholder content when `bgText` or `bgIcon` values are provided in the portfolio data
- showcase the new options in the sample data for Submerged and Subnautica Modder of the Year

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68db6fd82e1c8325b4b59dd519a948b3