### PR TITLE
Add side project filtering toggle and banner

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,17 @@
                 <div id="contact" class="contact" aria-label="Contact"></div>
             </div>
         </div>
+        <div class="header-actions">
+            <div class="toggle-group">
+                <input type="checkbox" id="toggle-sideprojects" class="toggle-input"/>
+                <label for="toggle-sideprojects" class="toggle">
+                    <span class="toggle-track" aria-hidden="true">
+                        <span class="toggle-thumb"></span>
+                    </span>
+                    <span class="toggle-text">Show side projects</span>
+                </label>
+            </div>
+        </div>
     </header>
 
     <div id="categories"></div>
@@ -50,6 +61,7 @@
         <img class="bg" alt=""/>
         <div class="bg-placeholder" aria-hidden="true" hidden></div>
         <div class="scrim-base" aria-hidden="true"></div>
+        <div class="sideproject-banner" aria-hidden="true" hidden>Side project</div>
 
         <div class="ribbon award-ribbon" aria-hidden="true" hidden></div>
         <div class="ribbon notable-ribbon" aria-hidden="true" hidden></div>

--- a/docs/portfolio-data.json
+++ b/docs/portfolio-data.json
@@ -357,6 +357,7 @@
                     "summary": "Various mods for Subnautica that I created over time",
                     "bgIcon": "",
                     "details": "",
+                    "sideproject": true,
                     "client": {
                         "name": "Independent Project"
                     },
@@ -379,6 +380,7 @@
                     "summary": "Entry for Neuro-sama Game Jam 2",
                     "bg": "images/fragmented.png",
                     "details": "Neuro can recount the past... only when there's enough room.",
+                    "sideproject": true,
                     "award": {
                         "text": "This project got 5th place out of 273 entries in Neuro-sama Game Jam 2.",
                         "url": "https://itch.io/jam/neuro/results"
@@ -405,6 +407,7 @@
                     "summary": "Entry for the Neuro-sama Birthday Game Jam",
                     "bg": "images/tutelquest.png",
                     "details": "Vedal awakens from a rough night, hearing Neuro call out in distress, then gets pulled into a mysterious digital world.",
+                    "sideproject": true,
                     "award": {
                         "text": "This project won 1st place out of 122 entries in the Neuro-sama Birthday Game Jam.",
                         "url": "https://itch.io/jam/neurosama-birthday-game-jam/results",

--- a/docs/portfolio.css
+++ b/docs/portfolio.css
@@ -151,6 +151,93 @@ body {
     }
 }
 
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.toggle-group {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.toggle-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    color: var(--muted);
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: .02em;
+    user-select: none;
+    padding: 6px 8px;
+    border-radius: 999px;
+}
+
+.toggle:hover .toggle-text,
+.toggle:focus-visible .toggle-text,
+.toggle-input:focus-visible + .toggle .toggle-text {
+    color: var(--text);
+}
+
+.toggle-input:focus-visible + .toggle {
+    outline: 2px solid rgba(99, 102, 241, .65);
+    outline-offset: 2px;
+}
+
+.toggle-track {
+    position: relative;
+    width: 46px;
+    height: 26px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, .28);
+    transition: background .2s ease;
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, .35);
+}
+
+.toggle-thumb {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 20px;
+    height: 20px;
+    border-radius: 999px;
+    background: #fff;
+    box-shadow: 0 6px 12px rgba(15, 23, 42, .32);
+    transition: transform .2s ease, background .2s ease;
+}
+
+.toggle-input:checked + .toggle .toggle-track {
+    background: linear-gradient(135deg, var(--brand), var(--notable));
+}
+
+.toggle-input:checked + .toggle .toggle-thumb {
+    transform: translateX(20px);
+    background: #f8fafc;
+}
+
+.toggle-text {
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: .2em;
+    white-space: nowrap;
+}
+
 .identity {
     display: flex;
     gap: 16px;
@@ -320,6 +407,27 @@ h2 {
         linear-gradient(180deg, rgba(0, 0, 0, .78) 0%, rgba(0, 0, 0, .42) 36%, rgba(0, 0, 0, .12) 70%, rgba(0, 0, 0, 0) 100%),
         linear-gradient(120deg, rgba(0, 0, 0, .28), rgba(0, 0, 0, .14) 52%, rgba(0, 0, 0, .08) 88%);
     transition: background .2s ease;
+}
+
+.sideproject-banner {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 8px 16px 10px;
+    background: linear-gradient(180deg, rgba(15, 23, 42, .65), rgba(15, 23, 42, .82));
+    color: rgba(226, 232, 240, .92);
+    text-transform: uppercase;
+    letter-spacing: .32em;
+    font-size: 11px;
+    font-weight: 700;
+    text-align: center;
+    z-index: 1;
+    pointer-events: none;
+}
+
+.sideproject-banner[hidden] {
+    display: none;
 }
 
 .tile:hover .bg,


### PR DESCRIPTION
## Summary
- add a header toggle to control visibility of side projects
- mark side projects in the data and filter them out by default
- show a banner on side project cards to indicate their status

## Testing
- python -m json.tool docs/portfolio-data.json

------
https://chatgpt.com/codex/tasks/task_e_68dbe31651108325b555c80e648d161b